### PR TITLE
Added file path of the currently edited file as a second parameter

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -74,7 +74,7 @@ export default class ScriptLauncher extends Plugin {
 
 
 	runScript(script:Script) {
-		const process = spawn(script.path,[this.getVaultPath()]);
+		const process = spawn(script.path,[this.getVaultPath(),this.getFilePath()]);
 		process.stdout.on("data", (data:any) => {
 			console.log(`stdout: ${data}`);
 			new Notice(data);
@@ -100,6 +100,12 @@ export default class ScriptLauncher extends Plugin {
 			return adapter.getBasePath();
 		}
 		return null;
+	}
+	
+	getFilePath() {
+		if(app.workspace.getActiveFile() == null)
+			return "";
+		return app.workspace.getActiveFile().path;
 	}
 }
 


### PR DESCRIPTION
Making the currently viewed file accessible in the script enables the script to run exclusively on that file. This modification passes the full file path as a second parameter to the script.

1. Parameter: vault path
2. Parameter: file path of the currently viewed/edited file (or blank, if none exists)