### PR TITLE
fix cmd and bat execution on Windows

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -74,7 +74,7 @@ export default class ScriptLauncher extends Plugin {
 
 
 	runScript(script:Script) {
-		const process = spawn(script.path,[this.getVaultPath(),this.getFilePath()]);
+		const process = spawn(script.path, [this.getVaultPath(), this.getFilePath()], { shell: true });
 		process.stdout.on("data", (data:any) => {
 			console.log(`stdout: ${data}`);
 			new Notice(data);


### PR DESCRIPTION
Fixes silent failure caused by a Node security update when trying to run `cmd` and `bat` scripts on Windows with this plugin.

See:
https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
https://github.com/nodejs/node/issues/52554