### PR TITLE
Fix status bar icon rendering and empty-icon fallback

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Editor, FileSystemAdapter, MarkdownView, Notice, Plugin, PluginSettingTab, Setting, SuggestModal } from 'obsidian';
+import { App, Editor, FileSystemAdapter, MarkdownView, Notice, Plugin, PluginSettingTab, Setting, SuggestModal, setIcon } from 'obsidian';
 import { ChildProcess, spawn } from 'child_process';
 import * as fs from 'fs';
 
@@ -63,7 +63,15 @@ export default class ScriptLauncher extends Plugin {
 			if (!(this.verifiedScripts.has(script.path)) && !this.exists(script.path)) continue;
 			this.verifiedScripts.add(script.path);
 			const statusBarItemEl = this.addStatusBarItem();
-			statusBarItemEl.setText(script.icon ?? script.name);
+			if (script.icon) {
+				setIcon(statusBarItemEl, script.icon);
+				// setIcon does nothing if the icon name is invalid, so fall back to the name
+				if (statusBarItemEl.childElementCount === 0) {
+					statusBarItemEl.setText(script.name);
+				}
+			} else {
+				statusBarItemEl.setText(script.name);
+			}
 			statusBarItemEl.onClickEvent((_) => {
 				this.runScript(script);
 			})


### PR DESCRIPTION
The status bar button used setText(script.icon ?? script.name), which caused two bugs:

1. Clearing the Icon field stored an empty string, which the `??` operator did not catch, so setText("") made the button blank instead of falling back to the script name.

2. setText always renders plain text, so a valid icon name was shown as literal text instead of an actual icon.

Use Obsidian's setIcon() to render Lucide icons, treat an empty icon string the same as no icon, and fall back to the script name when an icon name is invalid (setIcon renders nothing in that case).